### PR TITLE
App extension: Bug Fix - send the keys file does not work correctly

### DIFF
--- a/RiotShareExtension/Model/ShareExtensionManager.m
+++ b/RiotShareExtension/Model/ShareExtensionManager.m
@@ -450,7 +450,11 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
         }
         return;
     }
-    NSString *mimeType = [fileUrl pathExtension];
+    
+    NSString *mimeType;
+    CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[fileUrl pathExtension] , NULL);
+    mimeType = (__bridge_transfer NSString *) UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType);
+    CFRelease(uti);
     
     __weak typeof(self) weakSelf = self;
     


### PR DESCRIPTION
The attached file is not detected as keys files when the user selects it in the room history.

The associated mimetype was wrong